### PR TITLE
24 memo create

### DIFF
--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -1,17 +1,20 @@
-class MemosController < ApplicationController
-    def create
-        memo = Memo.new(memo_params)
-        # 成功した場合ステータスコードのみ返す
-        if memo.save
-            head :no_content
-            # 入力値が空の場合エラーメッセージをJSONで返す
-          else
-            render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity 
-          end
-    end
+# frozen_string_literal: true
 
-    private
-    def memo_params
-        params.require(:memo).permit( :title, :content)
+class MemosController < ApplicationController
+  def create
+    memo = Memo.new(memo_params)
+    # 成功した場合ステータスコードのみ返す
+    if memo.save
+      head :no_content
+    # 入力値が空の場合エラーメッセージをJSONで返す
+    else
+      render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def memo_params
+    params.require(:memo).permit(:title, :content)
+  end
 end

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -3,10 +3,8 @@
 class MemosController < ApplicationController
   def create
     memo = Memo.new(memo_params)
-    # 成功した場合ステータスコードのみ返す
     if memo.save
       head :no_content
-    # 入力値が空の場合エラーメッセージをJSONで返す
     else
       render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity
     end

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class MemosController < ApplicationController
+  # POST /memos
   def create
     memo = Memo.new(memo_params)
     if memo.save

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -1,0 +1,17 @@
+class MemosController < ApplicationController
+    def create
+        memo = Memo.new(memo_params)
+        # 成功した場合ステータスコードのみ返す
+        if memo.save
+            head :no_content
+            # 入力値が空の場合エラーメッセージをJSONで返す
+          else
+            render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity 
+          end
+    end
+
+    private
+    def memo_params
+        params.require(:memo).permit( :title, :content)
+    end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :tests, only: %i[index]
-  resources :memos
+  resources :memos, only: %i[create]
 end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   resources :tests, only: %i[index]
+  resources :memos
 end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -1,71 +1,34 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-
 RSpec.describe 'Memos' do
   describe 'MemoAPI' do
-    let(:valid_memo_params) { attributes_for(:memo) }
-    let(:empty_memo_params) { { title: '', content: '' } }
-    let(:empty_title_memo_params) { { title: '', content: 'test_content' } }
-    let(:empty_content_memo_params) { { title: 'test_title', content: '' } }
-
     context 'タイトルとコンテンツが有効な場合' do
-      before do
-        post '/memos', params: { memo: valid_memo_params }
-      end
+      let(:valid_memo_params) { attributes_for(:memo) }
 
-      it 'レコードが追加される' do
-        expect { post '/memos', params: { memo: valid_memo_params } }.to change(Memo, :count).by(+1)
-      end
-
-      it '204のステータスが返ってくる。' do
-        expect(response).to have_http_status(:no_content)
+      it 'memoレコードが追加され、204になる' do
+        aggregate_failures do
+          expect { post '/memos', params: { memo: valid_memo_params } }.to change(Memo, :count).by(+1)
+          expect(response).to have_http_status(:no_content)
+        end
       end
 
       it 'リクエストボディが返される。' do
+        post '/memos', params: { memo: valid_memo_params }
         expect(response.body).to be_empty
       end
     end
 
-    context 'タイトルとコンテンツが空の場合' do
-      before do
-        post '/memos', params: { memo: empty_memo_params }
-      end
+    context 'バリデーションエラーになる場合' do
+      let(:empty_memo_params) { { title: '', content: '' } }
 
       it '422のステータスが返ってくる' do
+        post '/memos', params: { memo: empty_memo_params }
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'response.bodyに「タイトルを入力してください,コンテンツを入力してください」が返ってくる。' do
-        expect(response.body).to eq('{"errors":["タイトルを入力してください","コンテンツを入力してください"]}')
-      end
-    end
-
-    context 'タイトルが空の場合' do
-      before do
-        post '/memos', params: { memo: empty_title_memo_params }
-      end
-
-      it '422のステータスが返ってくる' do
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it 'response.bodyに「タイトルを入力してください」が返ってくる。' do
-        expect(response.body).to eq('{"errors":["タイトルを入力してください"]}')
-      end
-    end
-
-    context 'コンテンツが空の場合' do
-      before do
-        post '/memos', params: { memo: empty_content_memo_params }
-      end
-
-      it '422のステータスが返ってくる' do
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it 'response.bodyに「コンテンツを入力してください」が返ってくる。' do
-        expect(response.body).to eq('{"errors":["コンテンツを入力してください"]}')
+        post '/memos', params: { memo: empty_memo_params }
+        expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください])
       end
     end
   end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -1,15 +1,71 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "Memos", type: :request do
-  subject(:memo) { build(:memo) }
-
+RSpec.describe 'Memos' do
   describe 'MemoAPI' do
-    context "タイトルとコンテンツが有効な場合" do
+    let(:valid_memo_params) { attributes_for(:memo) }
+    let(:empty_memo_params) { { title: '', content: '' } }
+    let(:empty_title_memo_params) { { title: '', content: 'test_content' } }
+    let(:empty_content_memo_params) { { title: 'test_title', content: '' } }
+
+    context 'タイトルとコンテンツが有効な場合' do
+      before do
+        post '/memos', params: { memo: valid_memo_params }
+      end
+
+      it 'レコードが追加される' do
+        expect { post '/memos', params: { memo: valid_memo_params } }.to change(Memo, :count).by(+1)
+      end
+
       it '204のステータスが返ってくる。' do
-        memo_params = attributes_for(:memo)
-        expect { post '/memos', params: { memo: memo_params } }.to change(Memo, :count).by(+1)
-        expect(response.status).to eq(204)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it 'リクエストボディが返される。' do
         expect(response.body).to be_empty
+      end
+    end
+
+    context 'タイトルとコンテンツが空の場合' do
+      before do
+        post '/memos', params: { memo: empty_memo_params }
+      end
+
+      it '422のステータスが返ってくる' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'response.bodyに「タイトルを入力してください,コンテンツを入力してください」が返ってくる。' do
+        expect(response.body).to eq('{"errors":["タイトルを入力してください","コンテンツを入力してください"]}')
+      end
+    end
+
+    context 'タイトルが空の場合' do
+      before do
+        post '/memos', params: { memo: empty_title_memo_params }
+      end
+
+      it '422のステータスが返ってくる' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'response.bodyに「タイトルを入力してください」が返ってくる。' do
+        expect(response.body).to eq('{"errors":["タイトルを入力してください"]}')
+      end
+    end
+
+    context 'コンテンツが空の場合' do
+      before do
+        post '/memos', params: { memo: empty_content_memo_params }
+      end
+
+      it '422のステータスが返ってくる' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'response.bodyに「コンテンツを入力してください」が返ってくる。' do
+        expect(response.body).to eq('{"errors":["コンテンツを入力してください"]}')
       end
     end
   end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Memos' do
-  describe 'MemoAPI' do
+RSpec.describe 'MemosController' do
+  describe 'POST /memos' do
     context 'タイトルとコンテンツが有効な場合' do
       let(:valid_memo_params) do
         { title: Faker::Lorem.sentence(word_count: 3), content: Faker::Lorem.paragraph(sentence_count: 5) }

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -3,32 +3,28 @@
 RSpec.describe 'Memos' do
   describe 'MemoAPI' do
     context 'タイトルとコンテンツが有効な場合' do
-      let(:valid_memo_params) { attributes_for(:memo) }
+      let(:valid_memo_params) do
+        { title: Faker::Lorem.sentence(word_count: 3), content: Faker::Lorem.paragraph(sentence_count: 5) }
+      end
 
       it 'memoレコードが追加され、204になる' do
         aggregate_failures do
           expect { post '/memos', params: { memo: valid_memo_params } }.to change(Memo, :count).by(+1)
           expect(response).to have_http_status(:no_content)
+          expect(response.body).to be_empty
         end
-      end
-
-      it 'リクエストボディが返される。' do
-        post '/memos', params: { memo: valid_memo_params }
-        expect(response.body).to be_empty
       end
     end
 
     context 'バリデーションエラーになる場合' do
       let(:empty_memo_params) { { title: '', content: '' } }
 
-      it '422のステータスが返ってくる' do
-        post '/memos', params: { memo: empty_memo_params }
-        expect(response).to have_http_status(:unprocessable_entity)
-      end
-
-      it 'response.bodyに「タイトルを入力してください,コンテンツを入力してください」が返ってくる。' do
-        post '/memos', params: { memo: empty_memo_params }
-        expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください])
+      it '422になり、エラーメッセージがレスポンスとして返る' do
+        aggregate_failures do
+          post '/memos', params: { memo: empty_memo_params }
+          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください])
+        end
       end
     end
   end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "Memos", type: :request do
+  subject(:memo) { build(:memo) }
+
+  describe 'MemoAPI' do
+    context "タイトルとコンテンツが有効な場合" do
+      it '204のステータスが返ってくる。' do
+        memo_params = attributes_for(:memo)
+        expect { post '/memos', params: { memo: memo_params } }.to change(Memo, :count).by(+1)
+        expect(response.status).to eq(204)
+        expect(response.body).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 対応するissue
- closes #24 

## 対応内容
・メモのコントローラーの作成
・routes.rbにメモのルーティングの設定を追加
・メモのcreateアクションの追加
成功時に204ステータスコードのみ返す。
失敗時にはエラーメッセージをJSON形式で返す。
・Rubocop実行