### PR TITLE
メモのdestroyするAPIを作成

### DIFF
--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -26,6 +26,8 @@ class MemosController < ApplicationController
     memo = Memo.find(params[:id])
     memo.destroy
     head :no_content
+  rescue ActiveRecord::RecordNotFound => e
+    render json: { message: e.message }, status: :not_found
   end
 
   private

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -11,7 +11,7 @@ class MemosController < ApplicationController
     end
   end
 
-  # PUT /memes/:id
+  # PUT /memos/:id
   def update
     memo = Memo.find(params[:id])
     if memo.update(update_memo_params)
@@ -19,6 +19,13 @@ class MemosController < ApplicationController
     else
       render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity
     end
+  end
+
+  # DELETE /memos/:id
+  def destroy
+    memo = Memo.find(params[:id])
+    memo.destroy
+    head :no_content
   end
 
   private

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -4,11 +4,11 @@
 #
 # Table name: comments
 #
-#  id                                  :bigint           not null, primary key
-#  content(コメントの内容)             :text(65535)      not null
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
-#  memo_id(コメントが参照するメモのID) :integer          not null
+#  id              :bigint           not null, primary key
+#  content(内容)   :text(65535)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  memo_id(メモID) :integer          not null
 #
 # Indexes
 #

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :tests, only: %i[index]
-  resources :memos, only: %i[create update]
+  resources :memos, only: %i[create update destroy]
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema[7.0].define(version: 0) do
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.integer "memo_id", null: false, comment: "コメントが参照するメモのID"
-    t.text "content", null: false, comment: "コメントの内容"
+    t.integer "memo_id", null: false, comment: "メモID"
+    t.text "content", null: false, comment: "内容"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["memo_id"], name: "index_comments_on_memo_id"

--- a/backend/spec/factories/comments.rb
+++ b/backend/spec/factories/comments.rb
@@ -4,11 +4,11 @@
 #
 # Table name: comments
 #
-#  id                                  :bigint           not null, primary key
-#  content(コメントの内容)             :text(65535)      not null
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
-#  memo_id(コメントが参照するメモのID) :integer          not null
+#  id              :bigint           not null, primary key
+#  content(内容)   :text(65535)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  memo_id(メモID) :integer          not null
 #
 # Indexes
 #

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -4,11 +4,11 @@
 #
 # Table name: comments
 #
-#  id                                  :bigint           not null, primary key
-#  content(コメントの内容)             :text(65535)      not null
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
-#  memo_id(コメントが参照するメモのID) :integer          not null
+#  id              :bigint           not null, primary key
+#  content(内容)   :text(65535)      not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  memo_id(メモID) :integer          not null
 #
 # Indexes
 #

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -84,5 +84,14 @@ RSpec.describe 'MemosController' do
         end
       end
     end
+
+    context '存在しないメモを削除しようとした場合' do
+      it '404が返ることを確認する' do
+        aggregate_failures do
+          expect { delete '/memos/999' }.not_to change(Memo, :count)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
   end
 end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -72,4 +72,17 @@ RSpec.describe 'MemosController' do
       end
     end
   end
+
+  describe 'DELETE /memos/:id' do
+    context 'メモを削除しようとした場合' do
+      let!(:existing_memo) { create(:memo) }
+
+      it 'メモを削除されたことを確認する' do
+        aggregate_failures do
+          expect { delete "/memos/#{existing_memo.id}" }.to change(Memo, :count).by(-1)
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+    end
+  end
 end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'MemosController' do
     context '存在しないメモを削除しようとした場合' do
       it '404が返ることを確認する' do
         aggregate_failures do
-          expect { delete '/memos/999' }.not_to change(Memo, :count)
+          expect { delete '/memos/0' }.not_to change(Memo, :count)
           expect(response).to have_http_status(:not_found)
         end
       end

--- a/infra/backend/Dockerfile
+++ b/infra/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-bullseye
+FROM ruby:3.2.2
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
- closes #28 
## 対応内容
・メモのコントローラーに削除処理を追加
・routesにdestroyを追加
・削除機能のテストを追加