### PR TITLE
#30 メモのindexとshowのAPIを作成

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -36,3 +36,6 @@ Style/HashSyntax:
 
 RSpec/ExampleLength:
   Enabled: false
+
+Rails/Pluck:
+  Enabled: false

--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -36,6 +36,3 @@ Style/HashSyntax:
 
 RSpec/ExampleLength:
   Enabled: false
-
-Rails/Pluck:
-  Enabled: false

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,3 +1,9 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  private
+
+  def record_not_found(exception)
+    render json: { error: exception.message }, status: :not_found
+  end
 end

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -10,7 +10,8 @@ class MemosController < ApplicationController
   # GET /memos/:id
   def show
     memo = Memo.find(params[:id])
-    render json: { memo: memo }, status: :ok
+    comments = memo.comments.order(id: 'DESC')
+    render json: { memo: memo, comments: comments }, status: :ok
   end
 
   # POST /memos

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -1,18 +1,16 @@
 # frozen_string_literal: true
 
 class MemosController < ApplicationController
-  before_action :find_memo, only: %i[show update destroy]
-  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-
   # GET /memos
   def index
-    memos = Memo.all
+    memos = Memo.all.order(id: 'DESC')
     render json: { memos: memos }, status: :ok
   end
 
   # GET /memos/:id
   def show
-    render json: { memo: @memo }, status: :ok
+    memo = Memo.find(params[:id])
+    render json: { memo: memo }, status: :ok
   end
 
   # POST /memos
@@ -27,16 +25,19 @@ class MemosController < ApplicationController
 
   # PUT /memos/:id
   def update
-    if @memo.update(update_memo_params)
+    memo = Memo.find(params[:id])
+
+    if memo.update(update_memo_params)
       head :no_content
     else
-      render json: { errors: @memo.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   # DELETE /memos/:id
   def destroy
-    @memo.destroy
+    memo = Memo.find(params[:id])
+    memo.destroy
     head :no_content
   end
 
@@ -44,10 +45,6 @@ class MemosController < ApplicationController
 
   def record_not_found(exception)
     render json: { error: exception.message }, status: :not_found
-  end
-
-  def find_memo
-    @memo = Memo.find(params[:id])
   end
 
   def memo_params

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -9,9 +9,9 @@ class MemosController < ApplicationController
 
   # GET /memos/:id
   def show
-    memo = Memo.find(params[:id])
-    comments = memo.comments.order(id: 'DESC')
-    render json: { memo: memo, comments: comments }, status: :ok
+    @memo = Memo.find(params[:id])
+    @comments = @memo.comments.order(id: 'DESC')
+    render 'show', status: :ok
   end
 
   # POST /memos

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -43,10 +43,6 @@ class MemosController < ApplicationController
 
   private
 
-  def record_not_found(exception)
-    render json: { error: exception.message }, status: :not_found
-  end
-
   def memo_params
     params.require(:memo).permit(:title, :content)
   end

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class MemosController < ApplicationController
+  before_action :find_memo, only: %i[show update destroy]
+
+  # GET /memos
+  def index
+    memos = Memo.all
+    render json: { memos: memos }, status: :ok
+  end
+
+  # GET /memos/:id
+  def show
+    render json: { memo: @memo }, status: :ok
+  end
+
   # POST /memos
   def create
     memo = Memo.new(memo_params)
@@ -13,24 +26,26 @@ class MemosController < ApplicationController
 
   # PUT /memos/:id
   def update
-    memo = Memo.find(params[:id])
-    if memo.update(update_memo_params)
+    if @memo.update(update_memo_params)
       head :no_content
     else
-      render json: { errors: memo.errors.full_messages }, status: :unprocessable_entity
+      render json: { errors: @memo.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   # DELETE /memos/:id
   def destroy
-    memo = Memo.find(params[:id])
-    memo.destroy
+    @memo.destroy
     head :no_content
   rescue ActiveRecord::RecordNotFound => e
     render json: { message: e.message }, status: :not_found
   end
 
   private
+
+  def find_memo
+    @memo = Memo.find(params[:id])
+  end
 
   def memo_params
     params.require(:memo).permit(:title, :content)

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -3,7 +3,7 @@
 class MemosController < ApplicationController
   # GET /memos
   def index
-    memos = Memo.all.order(id: 'DESC')
+    memos = Memo.order(id: 'DESC')
     render json: { memos: memos }, status: :ok
   end
 

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -2,6 +2,7 @@
 
 class MemosController < ApplicationController
   before_action :find_memo, only: %i[show update destroy]
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   # GET /memos
   def index
@@ -37,11 +38,13 @@ class MemosController < ApplicationController
   def destroy
     @memo.destroy
     head :no_content
-  rescue ActiveRecord::RecordNotFound => e
-    render json: { message: e.message }, status: :not_found
   end
 
   private
+
+  def record_not_found(exception)
+    render json: { error: exception.message }, status: :not_found
+  end
 
   def find_memo
     @memo = Memo.find(params[:id])

--- a/backend/app/views/memos/show.json.jbuilder
+++ b/backend/app/views/memos/show.json.jbuilder
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+json.memo do
+  json.id @memo.id
+  json.title @memo.title
+  json.content @memo.content
+  json.created_at @memo.created_at
+  json.updated_at @memo.updated_at
+
+  json.comments @comments do |comment|
+    json.id comment.id
+    json.content comment.content
+    json.created_at comment.created_at
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   resources :tests, only: %i[index]
-  resources :memos, only: %i[create update destroy]
+  resources :memos, only: %i[index show create update destroy]
 end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -1,6 +1,41 @@
 # frozen_string_literal: true
 
 RSpec.describe 'MemosController' do
+  describe 'GET /memos' do
+    context 'メモが存在する場合' do
+      before { create_list(:memo, 3) }
+
+      it '全てのメモが取得できることを確認する' do
+        aggregate_failures do
+          get '/memos'
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['memos'].length).to eq(3)
+        end
+      end
+    end
+  end
+
+  describe 'GET /memos/:id' do
+    context 'メモが存在する場合' do
+      let!(:memo) { create(:memo) }
+
+      it '指定したメモが取得できることを確認する' do
+        aggregate_failures do
+          get "/memos/#{memo.id}"
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['memo']['id']).to eq(memo.id)
+        end
+      end
+    end
+
+    context '存在しないメモを取得しようとした場合' do
+      it '404が返ることを確認する' do
+        get '/memos/0'
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'POST /memos' do
     context 'タイトルとコンテンツが有効な場合' do
       let(:valid_memo_params) do

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'MemosController' do
       let!(:memo) { create(:memo) }
       let!(:comments) { create_list(:comment, 3, memo: memo) }
 
-      it '指定したメモが取得できることを確認する' do
+      it '指定したメモ、コメントが取得できることを確認する' do
         aggregate_failures do
           get "/memos/#{memo.id}"
           expect(response).to have_http_status(:ok)

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -3,13 +3,16 @@
 RSpec.describe 'MemosController' do
   describe 'GET /memos' do
     context 'メモが存在する場合' do
-      before { create_list(:memo, 3) }
+      let!(:memos) { create_list(:memo, 3) }
 
-      it '全てのメモが取得できることを確認する' do
+      it '全てのメモが取得でき降順で並び変えられていることを確認する' do
         aggregate_failures do
           get '/memos'
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body['memos'].length).to eq(3)
+          result_memo_ids = response.parsed_body['memos'].map { _1['id'] }
+          expected_memo_ids = memos.reverse.map(&:id)
+          expect(result_memo_ids).to eq(expected_memo_ids)
         end
       end
     end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe 'MemosController' do
 
       it '指定したメモ、コメントが取得できることを確認する' do
         aggregate_failures do
-          get "/memos/#{memo.id}"
+          get "/memos/#{memo.id}", headers: { Accept: 'application/json' }
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body['memo']['id']).to eq(memo.id)
-          expect(response.parsed_body['comments'].length).to eq(3)
-          result_comment_ids = response.parsed_body['comments'].map { _1['id'] } # rubocop:disable Rails/Pluck
+          expect(response.parsed_body['memo']['comments'].length).to eq(3)
+          result_comment_ids = response.parsed_body['memo']['comments'].map { _1['id'] } # rubocop:disable Rails/Pluck
           expected_comments_ids = comments.reverse.map(&:id)
           expect(result_comment_ids).to eq(expected_comments_ids)
         end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'MemosController' do
           get '/memos'
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body['memos'].length).to eq(3)
-          result_memo_ids = response.parsed_body['memos'].map { _1['id'] }
+          result_memo_ids = response.parsed_body['memos'].map { _1['id'] } # rubocop:disable Rails/Pluck
           expected_memo_ids = memos.reverse.map(&:id)
           expect(result_memo_ids).to eq(expected_memo_ids)
         end
@@ -29,7 +29,7 @@ RSpec.describe 'MemosController' do
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body['memo']['id']).to eq(memo.id)
           expect(response.parsed_body['comments'].length).to eq(3)
-          result_comment_ids = response.parsed_body['comments'].map { _1['id'] }
+          result_comment_ids = response.parsed_body['comments'].map { _1['id'] } # rubocop:disable Rails/Pluck
           expected_comments_ids = comments.reverse.map(&:id)
           expect(result_comment_ids).to eq(expected_comments_ids)
         end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -21,12 +21,17 @@ RSpec.describe 'MemosController' do
   describe 'GET /memos/:id' do
     context 'メモが存在する場合' do
       let!(:memo) { create(:memo) }
+      let!(:comments) { create_list(:comment, 3, memo: memo) }
 
       it '指定したメモが取得できることを確認する' do
         aggregate_failures do
           get "/memos/#{memo.id}"
           expect(response).to have_http_status(:ok)
           expect(response.parsed_body['memo']['id']).to eq(memo.id)
+          expect(response.parsed_body['comments'].length).to eq(3)
+          result_comment_ids = response.parsed_body['comments'].map { _1['id'] }
+          expected_comments_ids = comments.reverse.map(&:id)
+          expect(result_comment_ids).to eq(expected_comments_ids)
         end
       end
     end


### PR DESCRIPTION
## 対応するissue
- closes #30 
## 対応内容
・routesにindexとshowを追加
・memo_controllerにindexとshowを追加
・controllerのmemo_findの処理をbefore_actionで共通化
・before_actionで共通化したことにより、例外がfind_memo内で発生し、アクション内で捕捉できなくなってしまったため、rescue_from でコントローラー全体を捕捉できるように変更
・rspecの作成