### PR TITLE
openapi.ymlのurlの定義をhttpsからhttpに変更

### DIFF
--- a/backend/doc/openapi.yml
+++ b/backend/doc/openapi.yml
@@ -3,7 +3,7 @@ info:
   title: progaku-archive
   version: 1.0.0
 servers:
-  - url: https://localhost:3000
+  - url: http://localhost:3000
     description: 開発環境
 tags:
   - name: メモ


### PR DESCRIPTION
## 対応するissue
issue 36 のバグ修正

## 対応内容
- openapi.ymlのスキーム名をhttpsからhttpへ変更