### PR TITLE
Dockerコマンドを実行時のDB接続エラーのバグ修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       - 3000:3000
     command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
   db:
     image: mysql:8.0
     platform: linux/amd64
@@ -27,6 +28,11 @@ services:
       MYSQL_ROOT_PASSWORD: root
     ports:
       - 3306:3306
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "db", "-u", "root", "-proot"]
+      interval: 5s
+      timeout: 10s
+      retries: 5
 volumes:
   db-data:
     driver: local


### PR DESCRIPTION
## 対応するissue
- closes #38 

## 対応内容
1. Dockerコマンド実行時、DBが接続可能状態になるまで待つようにhealthcheckを追加
2. healthcheckでは以下の確認を行うように設定
- mysqlのpingコマンドを実行し接続可能状態になっているか確認
- 5秒の間隔でpingコマンドを実行
- タイムアウト時間は10秒
- リトライ回数は5回に設定
上記のhealthcheckを通過した場合のみ実行するようにすることでDB接続のバグを解消