### PR TITLE
Enhance/#61 add rspec coverage

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -27,3 +27,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+
+# coverage files
+/coverage

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -83,4 +83,7 @@ group :test do
 
   # Github: https://github.com/faker-ruby/faker
   gem 'faker' # ランダムなテストデータ生成に使用
+
+  # Github: https://github.com/simplecov-ruby/simplecov
+  gem 'simplecov', require: false # テストカバレッジを取得するためのgem
 end

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     diffy (3.4.2)
+    docile (1.4.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -255,6 +256,12 @@ GEM
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     stringio (3.0.8)
     thor (1.2.2)
     timeout (0.4.0)
@@ -291,6 +298,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  simplecov
   tzinfo-data
 
 RUBY VERSION

--- a/backend/app/controllers/tests_controller.rb
+++ b/backend/app/controllers/tests_controller.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class TestsController < ApplicationController
-  # TODO: 動作確認用のコードなので、実際にAPIが作成されたら削除する
-  # 対応するissue: https://github.com/Progaku-copy/progaku-archive/issues/5
-  def index
-    render json: { key: 'Hello World!' }
-  end
-end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,4 +1,3 @@
 Rails.application.routes.draw do
-  resources :tests, only: %i[index]
   resources :memos, only: %i[index show create update destroy]
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -1,4 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+require 'simplecov'
+SimpleCov.start 'rails'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -4,6 +4,8 @@ SimpleCov.start 'rails' do
   add_filter '/app/channels/'
   add_filter '/app/jobs/'
   add_filter '/app/mailers/'
+  enable_coverage :branch
+  minimum_coverage line: 75, branch: 75
 end
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -1,6 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  add_filter '/app/channels/'
+  add_filter '/app/jobs/'
+  add_filter '/app/mailers/'
+end
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -1,11 +1,14 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'simplecov'
+require_relative 'simple_cov/formatter/branch_line_cov_formatter'
+
 SimpleCov.start 'rails' do
   add_filter '/app/channels/'
   add_filter '/app/jobs/'
   add_filter '/app/mailers/'
   enable_coverage :branch
   minimum_coverage line: 75, branch: 75
+  formatter SimpleCov::Formatter::BranchLineCovFormatter
 end
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'

--- a/backend/spec/simple_cov/formatter/branch_line_cov_formatter.rb
+++ b/backend/spec/simple_cov/formatter/branch_line_cov_formatter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SimpleCov
+  module Formatter
+    class BranchLineCovFormatter
+      # テストカバレッジ出力用のコードであるため
+      # rubocop:disable all
+      def format(result)
+        puts 'Coverage Report'
+        puts '======================'
+        puts "Lines: #{result.covered_lines}/#{result.total_lines} (#{result.covered_percent.round(2)}%)"
+        # ワークアラウンドなので、SimpleCov側が対応したら削除する。
+        # Ref: https://github.com/simplecov-ruby/simplecov/issues/1051#issuecomment-1426136364
+        if result.total_branches&.positive?
+          covered_branches_percent = 100.0 * result.covered_branches / result.total_branches
+          puts "Branch coverage: #{result.covered_branches} / #{result.total_branches} branches (#{covered_branches_percent.round(2)}%) covered."
+        end
+        puts '======================'
+      end
+      # rubocop:enable all
+    end
+  end
+end


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #61 
- closes #5
## 対応内容
<!-- ここに対応した内容を書く。 -->
- coverage分析を行うgem「SimpleCov」をインストール
- rails-helperにsimplecovを読み込む設定を追加
- 正確なcoverage分析を行うため現在使用していない「channels」「 jobs」「mailers」のファイルを分析対象外に設定
- 不要なファイルのtest controllerを削除　routesの定義も削除
- coverageファイルをgit対象外に設定  