### PR TITLE
Enhance/#51 change comments content to varchar1024

### DIFF
--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -15,6 +15,6 @@
 #  index_comments_on_memo_id  (memo_id)
 #
 class Comment < ApplicationRecord
-  validates :content, presence: true
+  validates :content, presence: true, length: { maximum: 1024 }
   belongs_to :memo
 end

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -5,7 +5,7 @@
 # Table name: comments
 #
 #  id              :bigint           not null, primary key
-#  content(内容)   :text(65535)      not null
+#  content(内容)   :string(1024)      not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  memo_id(メモID) :integer          not null

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -14,7 +14,7 @@ end
 
 create_table 'comments', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
   t.integer "memo_id", null: false, comment: 'メモID'
-  t.text "content", null: false, comment: '内容'
+  t.string "content", limit: 1024, null: false, comment: '内容'
   t.datetime "created_at", null: false
   t.datetime "updated_at", null: false
   t.index ["memo_id"], name: "index_comments_on_memo_id"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema[7.0].define(version: 0) do
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "memo_id", null: false, comment: "メモID"
-    t.text "content", null: false, comment: "内容"
+    t.string "content", limit: 1024, null: false, comment: "内容"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["memo_id"], name: "index_comments_on_memo_id"

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -52,6 +52,27 @@ RSpec.describe Comment do
         expect(comment.errors.full_messages).to eq ['内容を入力してください']
       end
     end
+
+    context 'contentが1025文字以上の場合' do
+      before { comment.content = 'a' * 1025 }
+
+      it 'valid?メソッドがfalseを返すこと' do
+        expect(comment).not_to be_valid
+      end
+
+      it 'errorsに「内容は1024文字以内で入力してください」と格納されること' do
+        comment.valid?
+        expect(comment.errors.full_messages).to eq ['内容は1024文字以内で入力してください']
+      end
+    end
+
+    context 'contentが1024文字の場合' do
+      before { comment.content = 'a' * 1024 }
+
+      it 'valid?メソッドがtrueを返すこと' do
+        expect(comment).to be_valid
+      end
+    end
   end
 
   describe 'アソシエーションのテスト' do

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -30,44 +30,38 @@ RSpec.describe Comment do
     context 'contentが空文字の場合' do
       before { comment.content = ' ' }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(comment).not_to be_valid
-      end
-
-      it 'errorsに「内容を入力してください」と格納されること' do
-        comment.valid?
-        expect(comment.errors.full_messages).to eq ['内容を入力してください']
+      it 'valid?メソッドがfalseを返し、errorsに「内容を入力してください」と格納されること' do
+        aggregate_failures do
+          expect(comment).not_to be_valid
+          expect(comment.errors.full_messages).to eq ['内容を入力してください']
+        end
       end
     end
 
     context 'contentがnilの場合' do
       before { comment.content = nil }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(comment).not_to be_valid
-      end
-
-      it 'errorsに「内容を入力してください」と格納されること' do
-        comment.valid?
-        expect(comment.errors.full_messages).to eq ['内容を入力してください']
+      it 'valid?メソッドがfalseを返し、errorsに「内容を入力してください」と格納されること' do
+        aggregate_failures do
+          expect(comment).not_to be_valid
+          expect(comment.errors.full_messages).to eq ['内容を入力してください']
+        end
       end
     end
 
-    context 'contentが1025文字以上の場合' do
-      before { comment.content = 'a' * 1025 }
+    context 'contentが1025文字の場合' do
+      before { comment.content = Faker::Lorem.characters(number: 1025) }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(comment).not_to be_valid
-      end
-
-      it 'errorsに「内容は1024文字以内で入力してください」と格納されること' do
-        comment.valid?
-        expect(comment.errors.full_messages).to eq ['内容は1024文字以内で入力してください']
+      it 'valid?メソッドがfalseを返し、errorsに「内容は1024文字以内で入力してください」と格納されること' do
+        aggregate_failures do
+          expect(comment).not_to be_valid
+          expect(comment.errors.full_messages).to eq ['内容は1024文字以内で入力してください']
+        end
       end
     end
 
     context 'contentが1024文字の場合' do
-      before { comment.content = 'a' * 1024 }
+      before { comment.content = Faker::Lorem.characters(number: 1024) }
 
       it 'valid?メソッドがtrueを返すこと' do
         expect(comment).to be_valid


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #59 

## 対応内容
<!-- ここに対応した内容を書く。 -->
- commentテーブルのcontentの定義をvarchar(1024)に変更
- commentのモデルにvalidationを追加
- commentのvalidationのテストを追加
