### PR TITLE
Feature/#58comment delete api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 infra/env/backend.env
+.idea

--- a/backend/app/controllers/comments_controller.rb
+++ b/backend/app/controllers/comments_controller.rb
@@ -12,6 +12,13 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    memo = Memo.find(params[:memo_id])
+    comment = memo.comments.find(params[:id])
+    comment.destroy
+    head :no_content
+  end
+
   private
 
   def comment_params

--- a/backend/app/controllers/comments_controller.rb
+++ b/backend/app/controllers/comments_controller.rb
@@ -13,10 +13,13 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    memo = Memo.find(params[:memo_id])
-    comment = memo.comments.find(params[:id])
-    comment.destroy
-    head :no_content
+    comment = Comment.find_by!(id: params[:id], memo_id: params[:memo_id])
+
+    if comment.destroy
+      head :no_content
+    else
+      render json: { errors: comment.errors.full_messages }, status: :unprocessable_entity
+    end
   end
 
   private

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   resources :memos, only: %i[index show create update destroy] do
-    resources :comments, only: %i[create]
+    resources :comments, only: %i[create destroy]
   end
 end

--- a/backend/spec/requests/comments_spec.rb
+++ b/backend/spec/requests/comments_spec.rb
@@ -33,4 +33,31 @@ RSpec.describe 'CommentsController' do
       end
     end
   end
+
+  describe 'DELETE /memos/:memo_id/comments/:id' do
+    context 'コメントが存在する場合' do
+      let!(:memo) { create(:memo) }
+      let!(:comment) { create(:comment, memo: memo) }
+
+      it 'コメントが削除され、204になる' do
+        aggregate_failures do
+          expect do
+            delete "/memos/#{memo.id}/comments/#{comment.id}", as: :json
+          end.to change(Comment, :count).by(-1)
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+    end
+
+    context 'コメントが存在しない場合' do
+      it '404が返ることを確認する' do
+        aggregate_failures do
+          expect do
+            delete '/memos/0/comments/0', as: :json
+          end.not_to change(Comment, :count)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
 end

--- a/backend/spec/requests/comments_spec.rb
+++ b/backend/spec/requests/comments_spec.rb
@@ -50,12 +50,47 @@ RSpec.describe 'CommentsController' do
     end
 
     context 'コメントが存在しない場合' do
+      let!(:memo) { create(:memo) }
+
       it '404が返ることを確認する' do
         aggregate_failures do
           expect do
-            delete '/memos/0/comments/0', as: :json
+            delete "/memos/#{memo.id}/comments/0", as: :json
           end.not_to change(Comment, :count)
           expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'メモが存在しない場合' do
+      let!(:memo) { create(:memo) }
+      let!(:comment) { create(:comment, memo: memo) }
+
+      it '404が返ることを確認する' do
+        aggregate_failures do
+          expect do
+            delete "/memos/0/comments/#{comment.id}", as: :json
+          end.not_to change(Comment, :count)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'コメントの削除に失敗した場合' do
+      let!(:memo) { create(:memo) }
+      let!(:comment) { create(:comment, memo: memo) }
+
+      before do
+        allow(Comment).to receive(:find_by).and_return(comment)
+        allow(comment).to receive(:destroy).and_return(false)
+      end
+
+      it '422が返ることを確認する' do
+        aggregate_failures do
+          expect do
+            delete "/memos/#{memo.id}/comments/#{comment.id}", as: :json
+          end.not_to change(Comment, :count)
+          expect(response).to have_http_status(:unprocessable_entity)
         end
       end
     end


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #58 

## 対応内容
<!-- ここに対応した内容を書く。 -->
- routesにcommentsのdestroyのルーティングを追加
- comments_controllerにコメントを削除するdestroyアクションを追加
- comments_specにコメント削除APIのテストケースを追加
