### PR TITLE
memoテーブル、memoモデルにuser_nameを追加する

### DIFF
--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -45,10 +45,10 @@ class MemosController < ApplicationController
   private
 
   def memo_params
-    params.require(:memo).permit(:title, :content)
+    params.require(:memo).permit(:title, :content, :user_name)
   end
 
   def update_memo_params
-    params.require(:memo).permit(:content)
+    params.require(:memo).permit(:content, :user_name)
   end
 end

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -45,10 +45,10 @@ class MemosController < ApplicationController
   private
 
   def memo_params
-    params.require(:memo).permit(:title, :content, :user_name)
+    params.require(:memo).permit(:title, :content, :poster)
   end
 
   def update_memo_params
-    params.require(:memo).permit(:content, :user_name)
+    params.require(:memo).permit(:content, :poster)
   end
 end

--- a/backend/app/models/memo.rb
+++ b/backend/app/models/memo.rb
@@ -4,16 +4,17 @@
 #
 # Table name: memos
 #
-#  id                           :bigint           not null, primary key
-#  content(メモの本文)          :text(65535)      not null
-#  title(メモのタイトル)        :string(255)      not null
-#  user_name(Slackのユーザー名) :string(21)       not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
+#  id                        :bigint           not null, primary key
+#  content(メモの本文)       :text(65535)      not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  title(メモのタイトル)     :string(255)      not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 class Memo < ApplicationRecord
-  validates :title, :content, presence: true
-  validates :user_name, presence: true, length: { maximum: 21 }
+  validates :title, presence: true
+  validates :content, presence: true
+  validates :poster, presence: true, length: { maximum: 50 }
   has_many :comments, dependent: :destroy
   has_many :memo_tags, dependent: :destroy
   has_many :tags, through: :memo_tags

--- a/backend/app/models/memo.rb
+++ b/backend/app/models/memo.rb
@@ -4,14 +4,16 @@
 #
 # Table name: memos
 #
-#  id                    :bigint           not null, primary key
-#  content(メモの本文)   :text(65535)      not null
-#  title(メモのタイトル) :string(255)      not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                           :bigint           not null, primary key
+#  content(メモの本文)          :text(65535)      not null
+#  title(メモのタイトル)        :string(255)      not null
+#  user_name(Slackのユーザー名) :string(21)       not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 class Memo < ApplicationRecord
   validates :title, :content, presence: true
+  validates :user_name, presence: true, length: { maximum: 21 }
   has_many :comments, dependent: :destroy
   has_many :memo_tags, dependent: :destroy
   has_many :tags, through: :memo_tags

--- a/backend/app/views/memos/show.json.jbuilder
+++ b/backend/app/views/memos/show.json.jbuilder
@@ -4,7 +4,7 @@ json.memo do
   json.id @memo.id
   json.title @memo.title
   json.content @memo.content
-  json.user_name @memo.user_name
+  json.poster @memo.poster
   json.created_at @memo.created_at
   json.updated_at @memo.updated_at
 

--- a/backend/app/views/memos/show.json.jbuilder
+++ b/backend/app/views/memos/show.json.jbuilder
@@ -4,6 +4,7 @@ json.memo do
   json.id @memo.id
   json.title @memo.title
   json.content @memo.content
+  json.user_name @memo.user_name
   json.created_at @memo.created_at
   json.updated_at @memo.updated_at
 

--- a/backend/config/locales/models/memo/ja.yml
+++ b/backend/config/locales/models/memo/ja.yml
@@ -4,6 +4,7 @@ ja:
       memo:
         title: タイトル
         content: コンテンツ
+        user_name: ユーザ名
       comment:
         content: 内容
       user:

--- a/backend/config/locales/models/memo/ja.yml
+++ b/backend/config/locales/models/memo/ja.yml
@@ -4,7 +4,7 @@ ja:
       memo:
         title: タイトル
         content: コンテンツ
-        user_name: ユーザ名
+        poster: Slackでの投稿者名
       comment:
         content: 内容
       user:

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -10,6 +10,7 @@ end
 create_table 'memos', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
   t.string 'title', null: false, comment: 'メモのタイトル'
   t.text 'content', null: false, comment: 'メモの本文'
+  t.string 'user_name', limit: 21, null: false, comment: 'Slackのユーザー名'
   t.timestamp 'created_at', null: false
   t.timestamp 'updated_at', null: false
 end

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -10,7 +10,7 @@ end
 create_table 'memos', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
   t.string 'title', null: false, comment: 'メモのタイトル'
   t.text 'content', null: false, comment: 'メモの本文'
-  t.string 'user_name', limit: 21, null: false, comment: 'Slackのユーザー名'
+  t.string 'poster', limit: 50, null: false, comment: 'Slackのユーザー名'
   t.timestamp 'created_at', null: false
   t.timestamp 'updated_at', null: false
 end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.2].define(version: 0) do
   create_table "memos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false, comment: "メモのタイトル"
     t.text "content", null: false, comment: "メモの本文"
+    t.string "user_name", limit: 21, null: false, comment: "Slackのユーザー名"
     t.timestamp "created_at", null: false
     t.timestamp "updated_at", null: false
   end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema[7.2].define(version: 0) do
   create_table "memos", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "title", null: false, comment: "メモのタイトル"
     t.text "content", null: false, comment: "メモの本文"
-    t.string "user_name", limit: 21, null: false, comment: "Slackのユーザー名"
+    t.string "poster", limit: 50, null: false, comment: "Slackのユーザー名"
     t.timestamp "created_at", null: false
     t.timestamp "updated_at", null: false
   end

--- a/backend/doc/components/memoSchema.yml
+++ b/backend/doc/components/memoSchema.yml
@@ -13,9 +13,9 @@ components:
         content:
           type: string
           example: メモの内容
-        user_name:
+        poster:
           type: string
-          example: ユーザ名
+          example: Slackでの投稿者名
         created_at:
           type: string
           format: date-time

--- a/backend/doc/components/memoSchema.yml
+++ b/backend/doc/components/memoSchema.yml
@@ -13,6 +13,9 @@ components:
         content:
           type: string
           example: メモの内容
+        user_name:
+          type: string
+          example: ユーザ名
         created_at:
           type: string
           format: date-time

--- a/backend/doc/paths/memo.yml
+++ b/backend/doc/paths/memo.yml
@@ -33,9 +33,9 @@ paths:
                 content:
                   type: string
                   example: メモの内容
-                user_name:
+                poster:
                   type: string
-                  example: ユーザ名
+                  example: Slackでの投稿者名
       responses:
         '204' :
           description: No Content

--- a/backend/doc/paths/memo.yml
+++ b/backend/doc/paths/memo.yml
@@ -33,6 +33,9 @@ paths:
                 content:
                   type: string
                   example: メモの内容
+                user_name:
+                  type: string
+                  example: ユーザ名
       responses:
         '204' :
           description: No Content

--- a/backend/spec/factories/memos.rb
+++ b/backend/spec/factories/memos.rb
@@ -4,17 +4,17 @@
 #
 # Table name: memos
 #
-#  id                           :bigint           not null, primary key
-#  content(メモの本文)          :text(65535)      not null
-#  title(メモのタイトル)        :string(255)      not null
-#  user_name(Slackのユーザー名) :string(21)       not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
+#  id                        :bigint           not null, primary key
+#  content(メモの本文)       :text(65535)      not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  title(メモのタイトル)     :string(255)      not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 FactoryBot.define do
   factory :memo do
     title { Faker::Lorem.sentence(word_count: 3) }
     content { Faker::Lorem.paragraph(sentence_count: 5) }
-    user_name { Faker::Name.name }
+    poster { Faker::Name.name }
   end
 end

--- a/backend/spec/factories/memos.rb
+++ b/backend/spec/factories/memos.rb
@@ -4,15 +4,17 @@
 #
 # Table name: memos
 #
-#  id                    :bigint           not null, primary key
-#  content(メモの本文)   :string(255)      not null
-#  title(メモのタイトル) :string(255)      not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                           :bigint           not null, primary key
+#  content(メモの本文)          :text(65535)      not null
+#  title(メモのタイトル)        :string(255)      not null
+#  user_name(Slackのユーザー名) :string(21)       not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 FactoryBot.define do
   factory :memo do
     title { Faker::Lorem.sentence(word_count: 3) }
     content { Faker::Lorem.paragraph(sentence_count: 5) }
+    user_name { Faker::Name.name }
   end
 end

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -4,18 +4,18 @@
 #
 # Table name: memos
 #
-#  id                           :bigint           not null, primary key
-#  content(メモの本文)          :text(65535)      not null
-#  title(メモのタイトル)        :string(255)      not null
-#  user_name(Slackのユーザー名) :string(21)       not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
+#  id                        :bigint           not null, primary key
+#  content(メモの本文)       :text(65535)      not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  title(メモのタイトル)     :string(255)      not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 RSpec.describe Memo do
-  subject(:memo) { build(:memo) }
+  let(:memo) { build(:memo) }
 
   describe 'バリデーションのテスト' do
-    context 'title と content と user_name が有効な場合' do
+    context '属性が有効な場合' do
       it 'valid?メソッドがtrueを返すこと' do
         expect(memo).to be_valid
       end
@@ -24,91 +24,77 @@ RSpec.describe Memo do
     context 'titleが空文字の場合' do
       before { memo.title = '' }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「タイトルを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+        end
       end
     end
 
     context 'titleがnilの場合' do
       before { memo.title = nil }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「タイトルを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['タイトルを入力してください']
+        end
       end
     end
 
     context 'contentが空文字の場合' do
       before { memo.content = '' }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「コンテンツを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+        end
       end
     end
 
     context 'contentがnilの場合' do
       before { memo.content = nil }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「コンテンツを入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+        end
       end
     end
 
-    context 'user_nameが空文字の場合' do
-      before { memo.user_name = '' }
+    context 'posterが空文字の場合' do
+      before { memo.poster = '' }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「ユーザー名を入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['ユーザ名を入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          memo.valid?
+          expect(memo.errors.full_messages).to eq ['Slackでの投稿者名を入力してください']
+        end
       end
     end
 
-    context 'user_nameがnilの場合' do
-      before { memo.user_name = nil }
+    context 'posterがnilの場合' do
+      before { memo.poster = nil }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「ユーザ名を入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['ユーザ名を入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['Slackでの投稿者名を入力してください']
+        end
       end
     end
 
-    context 'user_nameが21文字以上の場合' do
-      before { memo.user_name = 'a' * 22 }
+    context 'posterが50文字以上の場合' do
+      before { memo.poster = 'a' * 51 }
 
-      it 'valid?メソッドがfalseを返すこと' do
-        expect(memo).not_to be_valid
-      end
-
-      it 'errorsに「ユーザ名は21文字以内で入力してください」と格納されること' do
-        memo.valid?
-        expect(memo.errors.full_messages).to eq ['ユーザ名は21文字以内で入力してください']
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(memo).not_to be_valid
+          expect(memo.errors.full_messages).to eq ['Slackでの投稿者名は50文字以内で入力してください']
+        end
       end
     end
   end

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -4,17 +4,18 @@
 #
 # Table name: memos
 #
-#  id                    :bigint           not null, primary key
-#  content(メモの本文)   :text(65535)      not null
-#  title(メモのタイトル) :string(255)      not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                           :bigint           not null, primary key
+#  content(メモの本文)          :text(65535)      not null
+#  title(メモのタイトル)        :string(255)      not null
+#  user_name(Slackのユーザー名) :string(21)       not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 RSpec.describe Memo do
   subject(:memo) { build(:memo) }
 
   describe 'バリデーションのテスト' do
-    context 'title と content が有効な場合' do
+    context 'title と content と user_name が有効な場合' do
       it 'valid?メソッドがtrueを返すこと' do
         expect(memo).to be_valid
       end
@@ -69,6 +70,45 @@ RSpec.describe Memo do
       it 'errorsに「コンテンツを入力してください」と格納されること' do
         memo.valid?
         expect(memo.errors.full_messages).to eq ['コンテンツを入力してください']
+      end
+    end
+
+    context 'user_nameが空文字の場合' do
+      before { memo.user_name = '' }
+
+      it 'valid?メソッドがfalseを返すこと' do
+        expect(memo).not_to be_valid
+      end
+
+      it 'errorsに「ユーザー名を入力してください」と格納されること' do
+        memo.valid?
+        expect(memo.errors.full_messages).to eq ['ユーザ名を入力してください']
+      end
+    end
+
+    context 'user_nameがnilの場合' do
+      before { memo.user_name = nil }
+
+      it 'valid?メソッドがfalseを返すこと' do
+        expect(memo).not_to be_valid
+      end
+
+      it 'errorsに「ユーザ名を入力してください」と格納されること' do
+        memo.valid?
+        expect(memo.errors.full_messages).to eq ['ユーザ名を入力してください']
+      end
+    end
+
+    context 'user_nameが21文字以上の場合' do
+      before { memo.user_name = 'a' * 22 }
+
+      it 'valid?メソッドがfalseを返すこと' do
+        expect(memo).not_to be_valid
+      end
+
+      it 'errorsに「ユーザ名は21文字以内で入力してください」と格納されること' do
+        memo.valid?
+        expect(memo.errors.full_messages).to eq ['ユーザ名は21文字以内で入力してください']
       end
     end
   end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -70,9 +70,10 @@ RSpec.describe 'MemosController' do
   end
 
   describe 'POST /memos' do
-    context 'ログイン中かつタイトルとコンテンツが有効な場合' do
+    context 'ログイン中かつタイトルとコンテンツとユーザ名が有効な場合' do
       let(:valid_memo_params) do
-        { title: Faker::Lorem.sentence(word_count: 3), content: Faker::Lorem.paragraph(sentence_count: 5) }
+        { title: Faker::Lorem.sentence(word_count: 3), content: Faker::Lorem.paragraph(sentence_count: 5),
+          user_name: Faker::Name.name }
       end
 
       before { sign_in(user) }
@@ -89,7 +90,7 @@ RSpec.describe 'MemosController' do
     end
 
     context 'ログインしていてバリデーションエラーになる場合' do
-      let(:empty_memo_params) { { title: '', content: '' } }
+      let(:empty_memo_params) { { title: '', content: '', user_name: '' } }
 
       before { sign_in(user) }
 
@@ -99,7 +100,7 @@ RSpec.describe 'MemosController' do
           assert_request_schema_confirm
           expect(response).to have_http_status(:unprocessable_content)
           assert_response_schema_confirm(422)
-          expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください])
+          expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください ユーザ名を入力してください])
         end
       end
     end

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -70,10 +70,11 @@ RSpec.describe 'MemosController' do
   end
 
   describe 'POST /memos' do
-    context 'ログイン中かつタイトルとコンテンツとユーザ名が有効な場合' do
+    context 'ログイン中かつタイトルとコンテンツと投稿者が有効な場合' do
       let(:valid_memo_params) do
-        { title: Faker::Lorem.sentence(word_count: 3), content: Faker::Lorem.paragraph(sentence_count: 5),
-          user_name: Faker::Name.name }
+        { title: Faker::Lorem.sentence(word_count: 3),
+          content: Faker::Lorem.paragraph(sentence_count: 5),
+          poster: Faker::Name.name }
       end
 
       before { sign_in(user) }
@@ -100,7 +101,7 @@ RSpec.describe 'MemosController' do
           assert_request_schema_confirm
           expect(response).to have_http_status(:unprocessable_content)
           assert_response_schema_confirm(422)
-          expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください ユーザ名を入力してください])
+          expect(response.parsed_body['errors']).to eq(%w[タイトルを入力してください コンテンツを入力してください Slackでの投稿者名を入力してください])
         end
       end
     end

--- a/backend/test/fixtures/memos.yml
+++ b/backend/test/fixtures/memos.yml
@@ -2,11 +2,12 @@
 #
 # Table name: memos
 #
-#  id                    :bigint           not null, primary key
-#  content(メモの本文)   :string(255)      not null
-#  title(メモのタイトル) :string(255)      not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
+#  id                           :bigint           not null, primary key
+#  content(メモの本文)          :text(65535)      not null
+#  title(メモのタイトル)        :string(255)      not null
+#  user_name(Slackのユーザー名) :string(21)       not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 
 one:

--- a/backend/test/fixtures/memos.yml
+++ b/backend/test/fixtures/memos.yml
@@ -2,12 +2,12 @@
 #
 # Table name: memos
 #
-#  id                           :bigint           not null, primary key
-#  content(メモの本文)          :text(65535)      not null
-#  title(メモのタイトル)        :string(255)      not null
-#  user_name(Slackのユーザー名) :string(21)       not null
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null
+#  id                        :bigint           not null, primary key
+#  content(メモの本文)       :text(65535)      not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  title(メモのタイトル)     :string(255)      not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
 #
 
 one:


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #89 

## 対応内容
<!-- ここに対応した内容を書く。 -->
- メモテーブルにuser_nameカラムを追加
- メモモデルにuser_nameの項目、バリデーションを追加
- user_nameのテストケースを追加
