### PR TITLE
メモ一覧・詳細APIのレスポンスにタグ名を追加

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -90,4 +90,6 @@ group :test do
 
   # Github: https://github.com/simplecov-ruby/simplecov
   gem 'simplecov', require: false # テストカバレッジを取得するためのgem
+
+  gem "test-prof", "~> 1.4"
 end

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -42,6 +42,10 @@ gem 'rails-i18n' # i18n 日本語化対応用gem
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem "rack-cors"
 
+# bulk upsertを実現する
+# Github: https://github.com/zdennis/activerecord-import
+gem 'activerecord-import'
+
 group :development, :test do
   # Github: https://github.com/willnet/committee-rails
   gem 'committee-rails'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
       activemodel (= 7.2.1)
       activesupport (= 7.2.1)
       timeout (>= 0.4.0)
+    activerecord-import (1.8.1)
+      activerecord (>= 4.2)
     activestorage (7.2.1)
       actionpack (= 7.2.1)
       activejob (= 7.2.1)
@@ -101,9 +103,9 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     diffy (3.4.2)
+    docile (1.4.1)
     drb (2.2.1)
     erubi (1.13.0)
-    docile (1.4.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -297,6 +299,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   annotate
   bcrypt (~> 3.1.7)
   bootsnap

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -282,6 +282,7 @@ GEM
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     stringio (3.0.8)
+    test-prof (1.4.2)
     thor (1.3.2)
     timeout (0.4.1)
     tzinfo (2.0.6)
@@ -322,6 +323,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   simplecov
+  test-prof (~> 1.4)
   tzinfo-data
 
 RUBY VERSION

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -3,8 +3,11 @@
 class MemosController < ApplicationController
   # GET /memos
   def index
-    @memos = Memo::Query.call(filter_collection: Memo.preload(:tags), params: params)
-    render 'index', status: :ok
+    @memos = \
+      Memo::Query.call(
+        filter_collection: Memo.preload(:tags),
+        params: params
+      )
   rescue TypeError
     render json: { error: 'ページパラメータが無効です' }, status: :bad_request
   end
@@ -13,7 +16,6 @@ class MemosController < ApplicationController
   def show
     @memo = Memo.preload(:tags).find(params[:id])
     @comments = @memo.comments.order(id: 'DESC')
-    render 'show', status: :ok
   end
 
   # POST /memos

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -15,7 +15,7 @@ class MemosController < ApplicationController
   # GET /memos/:id
   def show
     @memo = Memo.preload(:tags).find(params[:id])
-    @comments = @memo.comments.order(id: 'DESC')
+    @comments = @memo.comments.order(id: :desc)
   end
 
   # POST /memos

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -10,7 +10,7 @@ class MemosController < ApplicationController
 
   # GET /memos/:id
   def show
-    @memo = Memo.find(params[:id])
+    @memo = Memo.includes(:tags).find(params[:id])
     @comments = @memo.comments.order(id: 'DESC')
     render 'show', status: :ok
   end

--- a/backend/app/controllers/memos_controller.rb
+++ b/backend/app/controllers/memos_controller.rb
@@ -3,14 +3,15 @@
 class MemosController < ApplicationController
   # GET /memos
   def index
-    render json: Memo::Query.call(filter_collection: Memo.all, params: params), status: :ok
+    @memos = Memo::Query.call(filter_collection: Memo.preload(:tags), params: params)
+    render 'index', status: :ok
   rescue TypeError
     render json: { error: 'ページパラメータが無効です' }, status: :bad_request
   end
 
   # GET /memos/:id
   def show
-    @memo = Memo.includes(:tags).find(params[:id])
+    @memo = Memo.preload(:tags).find(params[:id])
     @comments = @memo.comments.order(id: 'DESC')
     render 'show', status: :ok
   end

--- a/backend/app/models/memo.rb
+++ b/backend/app/models/memo.rb
@@ -37,7 +37,11 @@ class Memo < ApplicationRecord
             params: params
           )
         memo_count = memo_relation.count
-        { memos: PageFilter.resolve(scope: memo_relation, params: params),
+        paginated_memos = PageFilter.resolve(scope: memo_relation, params: params)
+        memo_with_tags = paginated_memos.includes(:tags).map do |memo|
+          memo.as_json.merge(tag_names: memo.tags.map(&:name))
+        end
+        { memos: memo_with_tags,
           total_page: memo_count.zero? ? FIRST_PAGE : (memo_count / PageFilter::MAX_ITEMS).ceil }
       end
 

--- a/backend/app/models/memo.rb
+++ b/backend/app/models/memo.rb
@@ -37,11 +37,7 @@ class Memo < ApplicationRecord
             params: params
           )
         memo_count = memo_relation.count
-        paginated_memos = PageFilter.resolve(scope: memo_relation, params: params)
-        memo_with_tags = paginated_memos.includes(:tags).map do |memo|
-          memo.as_json.merge(tag_names: memo.tags.map(&:name))
-        end
-        { memos: memo_with_tags,
+        { memos: PageFilter.resolve(scope: memo_relation, params: params),
           total_page: memo_count.zero? ? FIRST_PAGE : (memo_count / PageFilter::MAX_ITEMS).ceil }
       end
 

--- a/backend/app/views/memos/index.json.jbuilder
+++ b/backend/app/views/memos/index.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.memos @memos[:memos] do |memo|
+  json.id memo.id
+  json.title memo.title
+  json.content memo.content
+  json.poster memo.poster
+  json.created_at memo.created_at
+  json.updated_at memo.updated_at
+  json.tag_names memo.tags.map(&:name)
+end
+json.total_page @memos[:total_page]

--- a/backend/app/views/memos/show.json.jbuilder
+++ b/backend/app/views/memos/show.json.jbuilder
@@ -8,6 +8,8 @@ json.memo do
   json.created_at @memo.created_at
   json.updated_at @memo.updated_at
 
+  json.tag_names @memo.tags.map(&:name)
+
   json.comments @comments do |comment|
     json.id comment.id
     json.content comment.content

--- a/backend/doc/components/memoSchema.yml
+++ b/backend/doc/components/memoSchema.yml
@@ -24,6 +24,13 @@ components:
           type: string
           format: date-time
           example: 2021-01-01T00:00:00.000Z
+        tag_names:
+          type: array
+          items:
+            type: string
+          example:
+            - タグ1
+            - タグ2
         comments:
           type: array
           items:

--- a/backend/doc/paths/memo.yml
+++ b/backend/doc/paths/memo.yml
@@ -24,15 +24,10 @@ paths:
                     type: array
                     items:
                       $ref: '../components/memoSchema.yml#/components/schemas/memo'
-                  total_count:
-                    type: integer
-                    example: 1
                   total_pages:
                     type: integer
                     example: 1
-                  current_page:
-                    type: integer
-                    example: 1
+
         '400':
           description: Bad Request
           content:

--- a/backend/spec/factories/memos.rb
+++ b/backend/spec/factories/memos.rb
@@ -17,8 +17,10 @@ FactoryBot.define do
     content { Faker::Lorem.paragraph(sentence_count: 5) }
     poster { Faker::Name.name }
 
-    after :create do |memo|
-      create_list(:memo_tag, 3, memo: memo)
+    trait :with_tags do
+      after :create do |memo|
+        create_list(:memo_tag, 3, memo: memo)
+      end
     end
   end
 end

--- a/backend/spec/factories/memos.rb
+++ b/backend/spec/factories/memos.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     title { Faker::Lorem.sentence(word_count: 3) }
     content { Faker::Lorem.paragraph(sentence_count: 5) }
     poster { Faker::Name.name }
+
+    after :create do |memo|
+      create_list(:memo_tag, 3, memo: memo)
+    end
   end
 end

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -158,7 +158,19 @@ RSpec.describe Memo do
     end
 
     context 'ページネーション機能のテスト' do
-      before { create_list(:memo, 20) }
+      before do
+        memos_data = Array.new(20) do
+          {
+            title: Faker::Lorem.sentence(word_count: 3),
+            content: Faker::Lorem.paragraph(sentence_count: 5),
+            poster: Faker::Name.name,
+            created_at: Time.current,
+            updated_at: Time.current
+          }
+        end
+
+        Memo.bulk_import!(memos_data)
+      end
 
       it '指定したページ数のメモ、総数が取得できること' do
         aggregate_failures do

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -116,45 +116,12 @@ RSpec.describe Memo do
         create(:memo, title: 'その他 タイトル', content: 'その他 コンテンツ')
       ]
     end
-    let(:firts_expected_memo) do
-      {
-        'id' => memos[0].id,
-        'title' => memos[0].title,
-        'content' => memos[0].content,
-        'poster' => memos[0].poster,
-        'created_at' => memos[0].created_at,
-        'updated_at' => memos[0].updated_at,
-        :tag_names => memos[0].tags.map(&:name)
-      }
-    end
-    let(:second_expected_memo) do
-      {
-        'id' => memos[1].id,
-        'title' => memos[1].title,
-        'content' => memos[1].content,
-        'poster' => memos[1].poster,
-        'created_at' => memos[1].created_at,
-        'updated_at' => memos[1].updated_at,
-        :tag_names => memos[1].tags.map(&:name)
-      }
-    end
-    let!(:third_expected_memo) do
-      {
-        'id' => memos[2].id,
-        'title' => memos[2].title,
-        'content' => memos[2].content,
-        'poster' => memos[2].poster,
-        'created_at' => memos[2].created_at,
-        'updated_at' => memos[2].updated_at,
-        :tag_names => memos[2].tags.map(&:name)
-      }
-    end
 
     context 'タイトルで検索した場合' do
       it 'タイトルフィルターが正しく機能し、期待されるメモが取得できることを確認する' do
         aggregate_failures do
           result = Memo::Query.call(filter_collection: described_class.all, params: { title: 'テスト' })
-          expect(result[:memos]).to include(firts_expected_memo, second_expected_memo)
+          expect(result[:memos]).to include(memos[0], memos[1])
         end
       end
     end
@@ -162,7 +129,7 @@ RSpec.describe Memo do
     context 'コンテンツで検索した場合' do
       it 'コンテンツフィルターが正しく機能し、期待されるメモが取得できることを確認する' do
         result = Memo::Query.call(filter_collection: described_class.all, params: { content: 'コンテンツ' })
-        expect(result[:memos]).to include(firts_expected_memo, second_expected_memo, third_expected_memo)
+        expect(result[:memos]).to include(memos[0], memos[1], memos[2])
       end
     end
 
@@ -170,8 +137,8 @@ RSpec.describe Memo do
       it 'タイトルとコンテンツの両方でフィルターが正しく機能し、期待されるメモが取得できることを確認する' do
         aggregate_failures do
           result = Memo::Query.call(filter_collection: described_class.all, params: { title: 'その他', content: 'コンテンツ' })
-          expect(result[:memos]).to include(third_expected_memo)
-          expect(result[:memos]).not_to include(firts_expected_memo, second_expected_memo)
+          expect(result[:memos]).to include(memos[2])
+          expect(result[:memos]).not_to include(memos[0], memos[1])
         end
       end
     end
@@ -179,13 +146,13 @@ RSpec.describe Memo do
     context '並び替え機能のテスト' do
       it '昇順機能が正しく機能していること' do
         result = Memo::Query.call(filter_collection: described_class.all, params: { order: 'asc' })
-        expect(result[:memos]).to contain_exactly(firts_expected_memo, second_expected_memo, third_expected_memo)
+        expect(result[:memos]).to contain_exactly(memos[0], memos[1], memos[2])
       end
 
       it 'デフォルトで降順機能が正しく機能されていること' do
         aggregate_failures do
           result = Memo::Query.call(filter_collection: described_class.all, params: {})
-          expect(result[:memos]).to contain_exactly(third_expected_memo, second_expected_memo, firts_expected_memo)
+          expect(result[:memos]).to contain_exactly(memos[2], memos[1], memos[0])
         end
       end
     end
@@ -198,7 +165,7 @@ RSpec.describe Memo do
           result = Memo::Query.call(filter_collection: described_class.all, params: { page: 2 })
           memo_relation = described_class.order(id: :desc).limit(10).offset(10)
           expect(result[:memos].pluck('id')).to eq(memo_relation.pluck(:id))
-          expect(result[:total_page]).to eq(3)
+          expect(result[:total_page]).to eq(2)
         end
       end
     end

--- a/backend/spec/models/memo_spec.rb
+++ b/backend/spec/models/memo_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Memo do
           }
         end
 
-        Memo.bulk_import!(memos_data)
+        described_class.bulk_import!(memos_data)
       end
 
       it '指定したページ数のメモ、総数が取得できること' do

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -1,5 +1,9 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'simplecov'
+# ref: https://github.com/test-prof/test-prof/blob/master/docs/recipes/let_it_be.md
+require 'test_prof/recipes/rspec/let_it_be'
+# ref: https://github.com/test-prof/test-prof/blob/master/docs/recipes/before_all.md
+require 'test_prof/recipes/rspec/before_all'
 
 SimpleCov.start 'rails' do
   add_filter '/app/channels/'

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe 'MemosController' do
   let!(:user) { create(:user) }
 
   describe 'GET /memos' do
-    let!(:memos) do
+    # そこそこ重いSQLを発行するので、一回だけ呼ばれるようにしたい。
+    # ref: https://github.com/test-prof/test-prof/blob/master/docs/recipes/let_it_be.md
+    let_it_be(:memos) do
       memos_data = Array.new(20) do
         {
           title: Faker::Lorem.sentence(word_count: 3),
@@ -19,7 +21,9 @@ RSpec.describe 'MemosController' do
       Memo.order(:id).last(20)
     end
 
-    before do
+    # そこそこ重いSQLを発行するので、一回だけ呼ばれるようにしたい。
+    # ref: https://github.com/test-prof/test-prof/blob/master/docs/recipes/before_all.md
+    before_all do
       # Tagの生成
       tag_data = Array.new(3) do |n|
         {


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #114

## 対応内容
<!-- ここに対応した内容を書く。 -->
- メモ一覧API
  - Queryモジュールのcallメソッドにメモに紐づくタグを取得し、レスポンスに含める処理を追加
- メモ詳細API
  - includesでメモに紐づくタグ名を取得し、j builderでタグ名をレスポンスに含める処理を追加
- テスト、仕様書
  - Callメソッドのテストの期待値にタグの名前を追加
  - Openapi仕様書にタグ名の仕様を追加、不要なレスポンスの定義を削除

## 確認したいこと、聞きたいこと
- タグの取得方法について、includesを使用して取得するようにしましたが、outerjoin を使って1回のクエリで取得する方が良いのか等、パフォーマンス面また処理の記載箇所、分け方など気になる点などあれば指摘いただきたいです💦
- Rspecの期待値にタグの名前を追加するようにしたのですが、冗長な定義になってしまったこと、callメソッド内でレコードを取得するためにlet!で即時評価にしたのですが、そのことにより、memoテーブルに3件レコードが追加されてしまい、後のpage nationのテストで23件となり、total_pageが3件になってしまう副作用が出てしまいました。
context毎に期待値を定義する方法も検討したのですが、全てのcontextブロックに記載するとコード量も多くなってしまうかつ他の解決策が思いつかなかったため、とりあえず3件にしています。