### PR TITLE
コメントテーブルにposterカラムを追加する

### DIFF
--- a/backend/app/controllers/comments_controller.rb
+++ b/backend/app/controllers/comments_controller.rb
@@ -35,6 +35,6 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:content)
+    params.require(:comment).permit(:content, :poster)
   end
 end

--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -4,11 +4,12 @@
 #
 # Table name: comments
 #
-#  id              :bigint           not null, primary key
-#  content(内容)   :string(1024)     not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  memo_id(メモID) :bigint           not null
+#  id                        :bigint           not null, primary key
+#  content(内容)             :string(1024)     not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  memo_id(メモID)           :bigint           not null
 #
 # Indexes
 #
@@ -20,5 +21,6 @@
 #
 class Comment < ApplicationRecord
   validates :content, presence: true, length: { maximum: 1024 }
+  validates :poster, presence: true, length: { maximum: 50 }
   belongs_to :memo
 end

--- a/backend/config/locales/models/memo/ja.yml
+++ b/backend/config/locales/models/memo/ja.yml
@@ -7,6 +7,7 @@ ja:
         poster: Slackでの投稿者名
       comment:
         content: 内容
+        poster: Slackでの投稿者名
       user:
         account_name: アカウント名
         password: パスワード

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -18,6 +18,7 @@ end
 create_table 'comments', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
   t.bigint "memo_id", null: false, comment: 'メモID'
   t.string "content", limit: 1024, null: false, comment: '内容'
+  t.string 'poster', limit: 50, null: false, comment: 'Slackのユーザー名'
   t.datetime "created_at", null: false
   t.datetime "updated_at", null: false
   t.index ["memo_id"], name: "index_comments_on_memo_id"

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -14,6 +14,7 @@ ActiveRecord::Schema[7.2].define(version: 0) do
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "memo_id", null: false, comment: "メモID"
     t.string "content", limit: 1024, null: false, comment: "内容"
+    t.string "poster", limit: 50, null: false, comment: "Slackのユーザー名"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["memo_id"], name: "index_comments_on_memo_id"

--- a/backend/spec/factories/comments.rb
+++ b/backend/spec/factories/comments.rb
@@ -4,11 +4,12 @@
 #
 # Table name: comments
 #
-#  id              :bigint           not null, primary key
-#  content(内容)   :string(1024)     not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  memo_id(メモID) :bigint           not null
+#  id                        :bigint           not null, primary key
+#  content(内容)             :string(1024)     not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  memo_id(メモID)           :bigint           not null
 #
 # Indexes
 #
@@ -22,6 +23,7 @@
 FactoryBot.define do
   factory :comment do
     content { 'sample_comment' }
+    poster { Faker::Name.name }
     memo
   end
 end

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -4,11 +4,12 @@
 #
 # Table name: comments
 #
-#  id              :bigint           not null, primary key
-#  content(内容)   :string(1024)     not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  memo_id(メモID) :bigint           not null
+#  id                        :bigint           not null, primary key
+#  content(内容)             :string(1024)     not null
+#  poster(Slackのユーザー名) :string(50)       not null
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  memo_id(メモID)           :bigint           not null
 #
 # Indexes
 #
@@ -69,6 +70,39 @@ RSpec.describe Comment do
 
       it 'valid?メソッドがtrueを返すこと' do
         expect(comment).to be_valid
+      end
+    end
+
+    context 'posterが空文字の場合' do
+      before { comment.poster = '' }
+
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          comment.valid?
+          expect(comment.errors.full_messages).to eq ['Slackでの投稿者名を入力してください']
+        end
+      end
+    end
+
+    context 'posterがnilの場合' do
+      before { comment.poster = nil }
+
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(comment).not_to be_valid
+          expect(comment.errors.full_messages).to eq ['Slackでの投稿者名を入力してください']
+        end
+      end
+    end
+
+    context 'posterが50文字以上の場合' do
+      before { comment.poster = 'a' * 51 }
+
+      it 'valid?メソッドがfalseを返し、エラーメッセージが格納される' do
+        aggregate_failures do
+          expect(comment).not_to be_valid
+          expect(comment.errors.full_messages).to eq ['Slackでの投稿者名は50文字以内で入力してください']
+        end
       end
     end
   end

--- a/backend/spec/requests/comments_spec.rb
+++ b/backend/spec/requests/comments_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe 'CommentsController' do
   describe 'POST /memos/:memo_id/comments' do
     context 'ログイン中かつコンテンツが有効な場合' do
       let(:memo) { create(:memo) }
-      let(:params) { { content: Faker::Lorem.paragraph(sentence_count: 3) } }
+      let(:params) do
+        { content: Faker::Lorem.paragraph(sentence_count: 3),
+          poster: Faker::Name.name }
+      end
 
       before { sign_in(user) }
 
@@ -34,7 +37,7 @@ RSpec.describe 'CommentsController' do
             post "/memos/#{memo.id}/comments", params: { comment: params }, as: :json
           end.not_to change(Comment, :count)
           expect(response).to have_http_status(:unprocessable_content)
-          expect(response.parsed_body['errors']).to eq(['内容を入力してください'])
+          expect(response.parsed_body['errors']).to eq %w[内容を入力してください Slackでの投稿者名を入力してください]
         end
       end
     end


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #112 

## 対応内容
<!-- ここに対応した内容を書く。 -->
- コメントテーブルにslackの投稿者名を登録するposterカラムを追加する
- モデルにposterカラムのテストを追加