### PR TITLE
memoのタグのレスポンスにidを含めるように変更

### DIFF
--- a/backend/app/views/memos/index.json.jbuilder
+++ b/backend/app/views/memos/index.json.jbuilder
@@ -7,6 +7,9 @@ json.memos @memos[:memos] do |memo|
   json.poster memo.poster
   json.created_at memo.created_at
   json.updated_at memo.updated_at
-  json.tag_names memo.tags.map(&:name)
+  json.tags memo.tags do |tag|
+    json.id tag.id
+    json.name tag.name
+  end
 end
 json.total_page @memos[:total_page]

--- a/backend/app/views/memos/show.json.jbuilder
+++ b/backend/app/views/memos/show.json.jbuilder
@@ -8,7 +8,10 @@ json.memo do
   json.created_at @memo.created_at
   json.updated_at @memo.updated_at
 
-  json.tag_names @memo.tags.map(&:name)
+  json.tags @memo.tags do |tag|
+    json.id tag.id
+    json.name tag.name
+  end
 
   json.comments @comments do |comment|
     json.id comment.id

--- a/backend/doc/components/memoSchema.yml
+++ b/backend/doc/components/memoSchema.yml
@@ -24,13 +24,16 @@ components:
           type: string
           format: date-time
           example: 2021-01-01T00:00:00.000Z
-        tag_names:
+        tags:
           type: array
           items:
-            type: string
-          example:
-            - タグ1
-            - タグ2
+            properties:
+                id:
+                    type: integer
+                    example: 1
+                name:
+                    type: string
+                    example: "タグの名前"
         comments:
           type: array
           items:

--- a/backend/spec/requests/memos_spec.rb
+++ b/backend/spec/requests/memos_spec.rb
@@ -61,8 +61,10 @@ RSpec.describe 'MemosController' do
           expect(response.parsed_body['memos'].length).to eq(10)
           result_memo_ids = response.parsed_body['memos'].map { _1['id'] } # rubocop:disable Rails/Pluck
           expected_memo_ids = memos.reverse.map(&:id)
-          result_memo_tags = response.parsed_body['memos'].map { _1['tag_names'] } # rubocop:disable Rails/Pluck
-          expected_memo_tags = memos.reverse.map { |memo| memo.tags.map(&:name) }
+          result_memo_tags = response.parsed_body['memos'].map { _1['tags'] } # rubocop:disable Rails/Pluck
+          expected_memo_tags = memos.reverse.map do |memo|
+            memo.tags.map { |tag| { id: tag.id, name: tag.name } }
+          end.as_json
           expect(result_memo_ids).to eq(expected_memo_ids[0..9])
           expect(result_memo_tags).to eq(expected_memo_tags[0..9])
           expect(response.parsed_body['total_page']).to eq(2)
@@ -81,8 +83,10 @@ RSpec.describe 'MemosController' do
           expect(response.parsed_body['memos'].length).to eq(10)
           result_memo_ids = response.parsed_body['memos'].pluck('id')
           expected_memo_ids = memos.sort_by(&:id).reverse[10..19].map(&:id)
-          result_memo_tags = response.parsed_body['memos'].map { _1['tag_names'] } # rubocop:disable Rails/Pluck
-          expected_memo_tags = memos.reverse.map { |memo| memo.tags.map(&:name) }
+          result_memo_tags = response.parsed_body['memos'].map { _1['tags'] } # rubocop:disable Rails/Pluck
+          expected_memo_tags = memos.reverse.map do |memo|
+            memo.tags.map { |tag| { id: tag.id, name: tag.name } }
+          end.as_json
           expect(result_memo_ids).to eq(expected_memo_ids)
           expect(result_memo_tags).to eq(expected_memo_tags[10..19])
           expect(response.parsed_body['total_page']).to eq(2)


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #118 

## 対応内容
<!-- ここに対応した内容を書く。 -->
- レスポンスの名前をtagsに変更
- tags配列にidとnameの2つを返すように変更
- openapiとrspecの修正
