### PR TITLE
新設テーブル、仕様変更に対応するようにseedファイルを修正

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -8,21 +8,62 @@
 
 require "faker"
 
-10.times do |n|
-  User.create!(
-    email: Faker::Internet.unique.email,
-    password: Faker::Internet.password(min_length: 8)
-  )
+# ユーザの作成
+user_values = []
 
-  memo = Memo.create!(
-    title: Faker::Lorem.sentence(word_count:10),
-    content: Faker::Lorem.paragraphs(number: 5)
+3.times do |n|
+user_values << User.new(
+  account_name: Faker::Internet.unique.username(specifier: 6..9),
+  password: "test_user_test_user"
+)
+end
+User.import user_values
+
+# タグの作成
+tag_values = []
+
+10.times do |n|
+  tag_values << Tag.new(
+    name: Faker::Lorem.unique.word,
+    priority: "#{n} + 1"
   )
-        
-  10.times do |m|
-    Comment.create!(
-      memo_id: memo.id,
-      content:  Faker::Lorem.sentence(word_count:5)
-    )            
+end
+Tag.import tag_values
+
+#　メモの作成
+memo_values = []
+
+30.times do |n|
+  memo_values << Memo.new(
+    title: Faker::Lorem.sentence(word_count:10),
+    content: Faker::Lorem.paragraphs(number: 5),
+    poster: Faker::Name.name
+  )
+end
+Memo.import memo_values
+
+# メモのIDを取得
+new_memo_ids = Memo.order(created_at: :desc).limit(30).pluck(:id)
+
+# メモに紐づくコメントとタグを作成
+comment_values = []
+memo_tag_values = []
+tag_lds = Tag.pluck(:id)
+
+new_memo_ids.each do |memo_id|
+  10.times do |cn|
+    comment_values << Comment.new(
+      memo_id: memo_id,
+      content: Faker::Lorem.sentence(word_count:10),
+      poster: Faker::Name.name
+    )
+  end
+  3.times do |tn|
+    memo_tag_values << MemoTag.new(
+      memo_id: memo_id,
+      tag_id: tag_lds[tn]
+    )
   end
 end
+Comment.import comment_values
+MemoTag.import memo_tag_values


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #121 

## 対応内容
<!-- ここに対応した内容を書く。 -->
- memoとcommentにposterを追加
- tagのデータ、memoに紐づくtagのデータを追加
- 全てのテーブルに対してバルクインサートで追加できるように変更

**before(バルクインサート未使用時の生成時間)**
```
Seed finished in 2.970938335000028 seconds
```

**after(バルクインサート使用時の生成時間)**
```
Seed finished in 1.1119793760008179 seconds
```

hashからimportと両方試しましたが、実行時間あまり変わらなかったため、アクティブレコードのインスタンスでする方法を取りました！

**hashでバルクインサートした時の生成時間**
```
Seed finished in 1.1057915419987694 seconds
```

生成するデータ数が増えるとより顕著に差がでますね！
**memo1000件生成時**

**バルクインサート未使用**
```
Seed finished in 150.30980077800086 seconds
```

**バルクインサート使用**
```
Seed finished in 2.8444674180009315 seconds
```