### PR TITLE
sakuraVPSにデプロイ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 infra/env/backend.env
+infra/env/backend-prod.env
 .idea

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -36,8 +36,8 @@ test:
 # the values provided in this file. Alternatively, you can specify a connection
 # URL environment variable explicitly:
 #
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
+production:
+  url: <%= ENV["MY_APP_DATABASE_URL"] %>
 #
 # Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
 # for a full overview on how database connection configuration can be specified.

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -11,11 +11,7 @@ threads min_threads_count, max_threads_count
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-if ENV.fetch("RAILS_ENV", "development") == "development"
-  worker_timeout 3600
-elsif ENV.fetch("RAILS_ENV", "development") == "production"
-  worker_timeout 60
-end
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -41,3 +41,8 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+ssl_bind '0.0.0.0', '443', {
+  cert: '/etc/letsencrypt/live/progaku-archive.work/fullchain.pem',
+  key: '/etc/letsencrypt/live/progaku-archive.work/privkey.pem'
+}

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -11,7 +11,11 @@ threads min_threads_count, max_threads_count
 # Specifies the `worker_timeout` threshold that Puma will use to wait before
 # terminating a worker in development environments.
 #
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+if ENV.fetch("RAILS_ENV", "development") == "development"
+  worker_timeout 3600
+elsif ENV.fetch("RAILS_ENV", "development") == "production"
+  worker_timeout 60
+end
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,4 +16,5 @@ services:
       - ./infra/env/backend-prod.env
     ports:
       - 80:8080
+      - 443:443
     command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,4 +14,4 @@ services:
       - ./infra/env/backend-prod.env
     ports:
       - 8080:8080
-    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb -p 8080 -b '160.16.51.70"
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb -p 8080 -b \"http://160.16.51.70\""

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,5 +13,5 @@ services:
     env_file:
       - ./infra/env/backend-prod.env
     ports:
-      - 8080:8080
-    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb -p 8080 -b \"http://160.16.51.70\""
+      - 80:8080
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: ./infra/backend/Dockerfile
     volumes:
       - ./backend:/usr/src/app
+      - /etc/letsencrypt/live/progaku-archive.work/privkey.pem:/etc/letsencrypt/live/progaku-archive.work/privkey.pem
+      - /etc/letsencrypt/live/progaku-archive.work/fullchain.pem:/etc/letsencrypt/live/progaku-archive.work/fullchain.pem
     stdin_open: true
     tty: true
     env_file:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+  backend:
+    container_name: pa_backend
+    build:
+      context: .
+      dockerfile: ./infra/backend/Dockerfile
+    volumes:
+      - ./backend:/usr/src/app
+    stdin_open: true
+    tty: true
+    env_file:
+      - ./infra/env/backend-prod.env
+    ports:
+      - 8080:8080
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb -p 8080 -b '0.0.0.0'"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,4 +14,4 @@ services:
       - ./infra/env/backend-prod.env
     ports:
       - 8080:8080
-    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb -p 8080 -b '0.0.0.0'"
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec puma -C config/puma.rb -p 8080 -b '160.16.51.70"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     env_file:
       - ./infra/env/backend.env
     ports:
-      - 80:8080
+      - 8080:8080
     command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 8080 -b '0.0.0.0'"
     depends_on:
       db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     env_file:
       - ./infra/env/backend.env
     ports:
-      - 8080:8080
+      - 80:8080
     command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 8080 -b '0.0.0.0'"
     depends_on:
       db:


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
- closes #110 

## 対応内容
<!-- ここに対応した内容を書く。 -->
本番用に下記を行う
- Docker-compose.prodファイルを作成
 - SSL化に伴い、443ポートもホスト側とマッピングする
 - コンテナ内からホストのSSL証明書など参照できないため、マウントする
- Databaseymlの本番用の設定を追加
- pumaの設定を変更
  - ssl接続を有効化
  - 作成したSSL証明書、秘密鍵のパスを設定

## 相談内容
- タイムアウト時間をデフォルトの60秒にしているが問題ないか
- 現状、httpsへの強制リダイレクトなどしていないが必要かどうか(現状httpでもhttpsでも接続可能な状態となっている)
  VPS側の設定でフロントのサーバのIPからしかリクエスト受け付けないとかに制御すれば大丈夫ですかね？
 pumaには強制リダイレクト処理のオプションなどは用意されてなくって
大体、nginxとか使って、実現するみたいなのですが、サーバーの性能的にもnginxのサーバーまで起動するとよろしくないかなと思ったりしております 