### PR TITLE
commentsのValidationを削除

### DIFF
--- a/backend/app/models/comment.rb
+++ b/backend/app/models/comment.rb
@@ -5,7 +5,7 @@
 # Table name: comments
 #
 #  id                                             :bigint           not null, primary key
-#  content(内容)                                  :string(1024)     not null
+#  content(内容)                                  :text(65535)      not null
 #  poster_user_key(Slackの投稿者のID)             :string(255)      not null
 #  slack_parent_ts(Slackの親メッセージの投稿時刻) :string(255)      not null
 #  slack_ts(Slackの投稿時刻)                      :string(255)      not null
@@ -26,7 +26,7 @@
 #  fk_comments_poster_user_key  (poster_user_key => posters.user_key)
 #
 class Comment < ApplicationRecord
-  validates :content, presence: true, length: { maximum: 2048 }
+  validates :content, presence: true
   validates :slack_parent_ts, presence: true
   belongs_to :memo
   belongs_to :poster,

--- a/backend/db/Schemafile
+++ b/backend/db/Schemafile
@@ -28,7 +28,7 @@ end
 
 create_table 'comments', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
   t.bigint "memo_id", null: false, comment: 'メモID'
-  t.string "content", limit: 2048, null: false, comment: '内容'
+  t.text "content", null: false, comment: '内容'
   t.string 'poster_user_key',null: false, comment: 'Slackの投稿者のID'
   t.string 'slack_parent_ts',null: false, comment: 'Slackの親メッセージの投稿時刻'
   t.string 'slack_ts',null: false, comment: 'Slackの投稿時刻'

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema[7.2].define(version: 0) do
   create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "memo_id", null: false, comment: "メモID"
-    t.string "content", limit: 2048, null: false, comment: "内容"
+    t.text "content", null: false, comment: "内容"
     t.string "poster_user_key", null: false, comment: "Slackの投稿者のID"
     t.string "slack_parent_ts", null: false, comment: "Slackの親メッセージの投稿時刻"
     t.string "slack_ts", null: false, comment: "Slackの投稿時刻"

--- a/backend/spec/factories/comments.rb
+++ b/backend/spec/factories/comments.rb
@@ -5,7 +5,7 @@
 # Table name: comments
 #
 #  id                                             :bigint           not null, primary key
-#  content(内容)                                  :string(1024)     not null
+#  content(内容)                                  :text(65535)      not null
 #  poster_user_key(Slackの投稿者のID)             :string(255)      not null
 #  slack_parent_ts(Slackの親メッセージの投稿時刻) :string(255)      not null
 #  slack_ts(Slackの投稿時刻)                      :string(255)      not null

--- a/backend/spec/models/comment_spec.rb
+++ b/backend/spec/models/comment_spec.rb
@@ -5,7 +5,7 @@
 # Table name: comments
 #
 #  id                                             :bigint           not null, primary key
-#  content(内容)                                  :string(1024)     not null
+#  content(内容)                                  :text(65535)      not null
 #  poster_user_key(Slackの投稿者のID)             :string(255)      not null
 #  slack_parent_ts(Slackの親メッセージの投稿時刻) :string(255)      not null
 #  slack_ts(Slackの投稿時刻)                      :string(255)      not null
@@ -57,25 +57,6 @@ RSpec.describe Comment do
           expect(comment).not_to be_valid
           expect(comment.errors.full_messages).to eq ['内容を入力してください']
         end
-      end
-    end
-
-    context 'contentが1025文字の場合' do
-      before { comment.content = Faker::Lorem.characters(number: 1025) }
-
-      it 'valid?メソッドがfalseを返し、errorsに「内容は1024文字以内で入力してください」と格納されること' do
-        aggregate_failures do
-          expect(comment).not_to be_valid
-          expect(comment.errors.full_messages).to eq ['内容は1024文字以内で入力してください']
-        end
-      end
-    end
-
-    context 'contentが1024文字の場合' do
-      before { comment.content = Faker::Lorem.characters(number: 1024) }
-
-      it 'valid?メソッドがtrueを返すこと' do
-        expect(comment).to be_valid
       end
     end
 


### PR DESCRIPTION
## 対応するissue
<!-- ここに対応するissue番号を書く。issue番号が99なら、「- closes #99」と書く。 -->
## 対応内容
<!-- ここに対応した内容を書く。 -->
- Slackのスレッドにあたるコメントが1024文字しか許容されていなかった。スレッドで長文のケースもあるため修正 
